### PR TITLE
Add validation for `repoName` to block unicode characters

### DIFF
--- a/templates/collections.yaml
+++ b/templates/collections.yaml
@@ -40,6 +40,7 @@ spec:
           description: The name of the new collection project repository. For example, “my-new-collection-repo”.
           type: string
           maxLength: 100
+          pattern: '^([a-zA-Z][a-zA-Z0-9_]*)(-[a-zA-Z0-9_]+)*$'
         description:
           title: Collection description
           type: string
@@ -78,6 +79,9 @@ spec:
             catalogFilter:
               kind:
                 - System
+      errorMessage:
+        properties:
+          repoName: 'Unicode characters are not allowed'
   steps:
     - id: ansible
       name: Generating the Ansible Source Code Component

--- a/templates/collections.yaml
+++ b/templates/collections.yaml
@@ -79,9 +79,6 @@ spec:
             catalogFilter:
               kind:
                 - System
-      errorMessage:
-        properties:
-          repoName: 'Unicode characters are not allowed'
   steps:
     - id: ansible
       name: Generating the Ansible Source Code Component

--- a/templates/playbooks.yaml
+++ b/templates/playbooks.yaml
@@ -40,6 +40,7 @@ spec:
           description: The name of the new playbook project repository. For example, “my-new-playbook-repo”.
           type: string
           maxLength: 100
+          pattern: '^([a-zA-Z][a-zA-Z0-9_]*)(-[a-zA-Z0-9_]+)*$'
         description:
           title: Playbook description
           type: string
@@ -78,6 +79,9 @@ spec:
             catalogFilter:
               kind:
                 - System
+      errorMessage:
+        properties:
+          repoName: 'Unicode characters are not allowed'
   steps:
     - id: ansible
       name: Generating the Ansible Source Code Component

--- a/templates/playbooks.yaml
+++ b/templates/playbooks.yaml
@@ -79,9 +79,6 @@ spec:
             catalogFilter:
               kind:
                 - System
-      errorMessage:
-        properties:
-          repoName: 'Unicode characters are not allowed'
   steps:
     - id: ansible
       name: Generating the Ansible Source Code Component


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/AAP-30545