### PR TITLE
Update devfile.yaml

### DIFF
--- a/templates/devfile.yaml
+++ b/templates/devfile.yaml
@@ -45,7 +45,7 @@ spec:
       input:
         repositoryUrl: '${{ parameters.repositoryUrl }}'
         description: '${{ parameters.description }}'
-        applicationType: devfile-project
+        applicationType: devfile
         sourceControl: '${{ parameters.sourceControl }}'
 
   output:


### PR DESCRIPTION
Update application type to be `devfile` instead of `devfile-project`. 
The reason for this change is because we are not scaffolding a project and a single file instead.