### PR TITLE
Update template to make aaphostname dynamic and remove aapValidateCerts

### DIFF
--- a/generic-seed/template.yaml
+++ b/generic-seed/template.yaml
@@ -124,7 +124,7 @@ spec:
           resource: aaphostname
           ui:field: AAPResourcePicker
           default:
-            id: 0
+            id: 1
             name: Default
       errorMessage:
         properties:

--- a/generic-seed/template.yaml
+++ b/generic-seed/template.yaml
@@ -121,13 +121,11 @@ spec:
           default: seed_portal_content.yml
         aapHostName:
           title: AAP URL
-          type: string
-          ui:options:
-            rows: 5
-        aapValidateCerts:
-          title: AAP validate certs
-          type: boolean
-          default: false
+          resource: aaphostname
+          ui:field: AAPResourcePicker
+          default:
+            id: 0
+            name: Default
       errorMessage:
         properties:
           useCases: 'Select at least one use case.'
@@ -173,7 +171,6 @@ spec:
            extraVariables:
              aap_hostname: ${{ parameters.aapHostName }}
              aap_token: ${{ parameters.token }}
-             aap_validate_certs: ${{ parameters.aapValidateCerts }}
              usecases: ${{ parameters.useCases }}
              seed_usecase: ${{ parameters.useCases | useCaseNameFilter }}
              organization_name: ${{ parameters.organization | resourceFilter('name')}}


### PR DESCRIPTION
Related Issue : https://issues.redhat.com/browse/AAP-41193
Related PR : https://github.com/ansible/ansible-backstage-plugins/pull/190

# Description

This PR updates the ansible-rhdh-templates to: 

- Make aapHostname dynamic – The AAP hostname is now dynamically fetched from the app-config.yaml file.
- Remove aapValidateCerts from the parameters – This parameter is no longer displayed in the UI. However, the checkSSL value is now included in the extraVariables object within the payload to ensure the correct data is sent.