### PR TITLE
Split publish step into separate GitHub and GitLab actions for collections/playbooks templates

### DIFF
--- a/templates/collections.yaml
+++ b/templates/collections.yaml
@@ -110,8 +110,8 @@ spec:
           sourceControl: ${{ parameters.sourceControl }}
           devSpacesBaseUrl: ${{ steps.ansible.output.devSpacesBaseUrl }}
 
-    - id: publish
-      name: Publish
+    - id: publish_github
+      name: Publish to Github
       if: ${{ parameters.sourceControl == 'github.com' }}
       action: publish:github
       input:
@@ -122,8 +122,8 @@ spec:
         repoVisibility: 'public'
         defaultBranch: main
 
-    - id: publish
-      name: Publish
+    - id: publish_gitlab
+      name: Publish to Gitlab
       if: ${{ parameters.sourceControl == 'gitlab.com' }}
       action: publish:gitlab
       input:
@@ -138,13 +138,13 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps.publish_github.output.repoContentsUrl if parameters.sourceControl == 'github.com' else steps.publish_gitlab.output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
 
   output:
     links:
       - title: Repository
-        url: ${{ steps.publish.output.remoteUrl }}
+        url: ${{ steps.publish_github.output.remoteUrl if parameters.sourceControl == 'github.com' else steps.publish_gitlab.output.remoteUrl }}
 
       - title: Open in catalog
         icon: catalog

--- a/templates/playbooks.yaml
+++ b/templates/playbooks.yaml
@@ -110,8 +110,8 @@ spec:
           sourceControl: ${{ parameters.sourceControl }}
           devSpacesBaseUrl: ${{ steps.ansible.output.devSpacesBaseUrl }}
 
-    - id: publish
-      name: Publish
+    - id: publish_github
+      name: Publish to Github
       if: ${{ parameters.sourceControl == 'github.com' }}
       action: publish:github
       input:
@@ -122,8 +122,8 @@ spec:
         repoVisibility: 'public'
         defaultBranch: main
 
-    - id: publish
-      name: Publish
+    - id: publish_gitlab
+      name: Publish to Gitlab
       if: ${{ parameters.sourceControl == 'gitlab.com' }}
       action: publish:gitlab
       input:
@@ -138,13 +138,13 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps.publish_github.output.repoContentsUrl if parameters.sourceControl == 'github.com' else steps.publish_gitlab.output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
 
   output:
     links:
       - title: Repository
-        url: ${{ steps.publish.output.remoteUrl }}
+        url: ${{ steps.publish_github.output.remoteUrl if parameters.sourceControl == 'github.com' else steps.publish_gitlab.output.remoteUrl }}
 
       - title: Open in catalog
         icon: catalog


### PR DESCRIPTION
This PR separates the publish step into distinct Github and Gitlab actions with unique IDs. This ensures that only the relevant step executes based on the sourceControl option. Previously, both steps appeared as skipped in the UI, even when one executed correctly because of the same id.

### Current Behaviour:

![Screenshot 2025-03-19 at 2 10 02 PM](https://github.com/user-attachments/assets/8110c224-14ab-4661-9e8b-fb10c951e974)


### Behaviour after this change:

![Screenshot 2025-03-19 at 2 12 07 PM](https://github.com/user-attachments/assets/6cd33739-0e48-42e5-883c-554d506f296c)
OR

![Screenshot 2025-03-19 at 2 15 14 PM](https://github.com/user-attachments/assets/afef3f75-b975-45f4-8f8b-f0408a079d35)


