### PR TITLE
[EE] update templates based on enhanced SCMAuthPicker

### DIFF
--- a/templates/ee-cloud-automation.yaml
+++ b/templates/ee-cloud-automation.yaml
@@ -271,7 +271,7 @@ spec:
                             sourceControlProvider:
                               properties:
                                 provider:
-                                  const: Github
+                                  const: github
                             buildExecutionEnvironment:
                               title: Build Execution Environment
                               description: Trigger a build of the Execution Environment after publishing.
@@ -348,7 +348,7 @@ spec:
                             sourceControlProvider:
                               properties:
                                 provider:
-                                  const: Gitlab
+                                  const: gitlab
                 - properties:
                     publishToSCM:
                       const: false
@@ -420,7 +420,7 @@ spec:
     - id: publish-github
       name: Create and publish to a new GitHub Repository
       action: publish:github
-      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Github') }}
+      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'github') }}
       input:
         description: ${{ parameters.templateDescription }}
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
@@ -432,7 +432,7 @@ spec:
     - id: publish-gitlab
       name: Create and publish to a new GitLab Repository
       action: publish:gitlab
-      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Gitlab') }}
+      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab') }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         defaultBranch: 'main'
@@ -443,7 +443,7 @@ spec:
     - id: publish-github-pull-request
       name: Publish generated files as a Github Pull Request
       action: publish:github:pull-request
-      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Github') }}
+      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'github') }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         branchName: ${{ steps['prepare-publish'].output.generatedBranchName }}
@@ -455,7 +455,7 @@ spec:
     - id: publish-gitlab-merge-request
       name: Publish generated files as a Gitlab Merge Request
       action: publish:gitlab:merge-request
-      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Gitlab') }}
+      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab') }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         branchName: ${{ steps['prepare-publish'].output.generatedBranchName }}
@@ -491,24 +491,24 @@ spec:
           ${{ steps['create-ee-definition'].output.readmeContent }}
 
     links:
-      - title: ${{ parameters.publishAndBuild.sourceControlProvider.provider }} Repository
+      - title: ${{ parameters.publishAndBuild.sourceControlProvider.providerLabel }} Repository
         url: ${{ steps['prepare-publish'].output.generatedFullRepoUrl }}
         if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) }}
         icon: ${{ parameters.publishAndBuild.sourceControlProvider.provider | lower }}
 
       - title: GitHub Pull Request
         url: ${{ steps['publish-github-pull-request'].output.remoteUrl }}
-        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Github') }}
+        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'github') }}
         icon: github
 
-      - title: ${{ parameters.publishAndBuild.sourceControlProvider.provider }} EE Build Workflow Run
+      - title: ${{ parameters.publishAndBuild.sourceControlProvider.providerLabel }} EE Build Workflow Run
         url: "https://${{ steps['prepare-publish'].output.normalizedRepoUrl }}/actions/workflows/ee-build.yml"
         if: ${{ (parameters.publishAndBuild.buildExecutionEnvironment == true) }}
         icon: github
 
       - title: GitLab Merge Request
         url: ${{ steps['publish-gitlab-merge-request'].output.mergeRequestUrl	}}
-        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Gitlab') }}
+        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab') }}
 
 
       - title: View details in catalog

--- a/templates/ee-cloud-automation.yaml
+++ b/templates/ee-cloud-automation.yaml
@@ -245,7 +245,7 @@ spec:
                     sourceControlProvider:
                       title: Select source control provider
                       type: object
-                      ui:field: ScmAuthPicker
+                      ui:field: ScmSelector
                       ui:options:
                         providers:
                           - label: Github

--- a/templates/ee-cloud-automation.yaml
+++ b/templates/ee-cloud-automation.yaml
@@ -244,13 +244,16 @@ spec:
                       const: true
                     sourceControlProvider:
                       title: Select source control provider
-                      description: Choose your source control provider
-                      type: string
-                      enum:
-                        - Github
-                        - Gitlab
+                      type: object
                       ui:field: ScmAuthPicker
                       ui:options:
+                        providers:
+                          - label: Github
+                            provider: github
+                            host: github.com
+                          - label: Gitlab
+                            provider: gitlab
+                            host: gitlab.com
                         requestUserCredentials:
                           secretsKey: USER_OAUTH_TOKEN
                           additionalScopes:
@@ -259,34 +262,16 @@ spec:
                               - workflow
                             gitlab:
                               - write_repository
-                        hostMapping:
-                          Github: github.com
-                          Gitlab: gitlab.com
-                    repositoryOwner:
-                      title: Git organization or username
-                      type: string
-                      description: The organization or username that owns the Git repository
-                    repositoryName:
-                      title: Target Repository Name
-                      type: string
-                      description: Specify the name of the repository where the EE definition files will be published.
-                    createNewRepository:
-                      title: Create new repository
-                      type: boolean
-                      description: Create a new repository, if the specified one does not exist.
-                      default: false
-                      ui:help: "If unchecked, a new repository will not be created if the specified one does not exist. The generated files will not be published to a repository."
                   required:
                     - sourceControlProvider
-                    - repositoryOwner
-                    - repositoryName
-                    - createNewRepository
                   dependencies:
                     sourceControlProvider:
                       oneOf:
                         - properties:
                             sourceControlProvider:
-                              const: Github
+                              properties:
+                                provider:
+                                  const: Github
                             buildExecutionEnvironment:
                               title: Build Execution Environment
                               description: Trigger a build of the Execution Environment after publishing.
@@ -361,7 +346,9 @@ spec:
                                       const: false
                         - properties:
                             sourceControlProvider:
-                              const: Gitlab
+                              properties:
+                                provider:
+                                  const: Gitlab
                 - properties:
                     publishToSCM:
                       const: false
@@ -399,10 +386,10 @@ spec:
       name: Prepare for publishing
       if: ${{ parameters.publishAndBuild.publishToSCM }}
       input:
-        sourceControlProvider: ${{ parameters.publishAndBuild.sourceControlProvider }}
-        repositoryOwner: ${{ parameters.publishAndBuild.repositoryOwner }}
-        repositoryName: ${{ parameters.publishAndBuild.repositoryName }}
-        createNewRepository: ${{ parameters.publishAndBuild.createNewRepository }}
+        sourceControlProvider: ${{ parameters.publishAndBuild.sourceControlProvider.provider }}
+        repositoryOwner: ${{ parameters.publishAndBuild.sourceControlProvider.org }}
+        repositoryName: ${{ parameters.publishAndBuild.sourceControlProvider.repoName }}
+        createNewRepository: ${{ not parameters.publishAndBuild.sourceControlProvider.repoExists }}
         eeFileName: ${{ parameters.eeFileName }}
         contextDirName: ${{ steps['create-ee-definition'].output.contextDirName }}
         token: ${{ secrets.USER_OAUTH_TOKEN }}
@@ -423,7 +410,7 @@ spec:
             annotations:
               backstage.io/techdocs-ref: dir:.
               backstage.io/managed-by-location: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
-              ansible.io/scm-provider: ${{ parameters.publishAndBuild.sourceControlProvider }}
+              ansible.io/scm-provider: ${{ parameters.publishAndBuild.sourceControlProvider.provider }}
           spec:
             type: execution-environment
             owner: ${{ steps['create-ee-definition'].output.owner }}
@@ -433,7 +420,7 @@ spec:
     - id: publish-github
       name: Create and publish to a new GitHub Repository
       action: publish:github
-      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Github') }}
+      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Github') }}
       input:
         description: ${{ parameters.templateDescription }}
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
@@ -445,7 +432,7 @@ spec:
     - id: publish-gitlab
       name: Create and publish to a new GitLab Repository
       action: publish:gitlab
-      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Gitlab') }}
+      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Gitlab') }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         defaultBranch: 'main'
@@ -456,7 +443,7 @@ spec:
     - id: publish-github-pull-request
       name: Publish generated files as a Github Pull Request
       action: publish:github:pull-request
-      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Github') }}
+      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Github') }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         branchName: ${{ steps['prepare-publish'].output.generatedBranchName }}
@@ -468,7 +455,7 @@ spec:
     - id: publish-gitlab-merge-request
       name: Publish generated files as a Gitlab Merge Request
       action: publish:gitlab:merge-request
-      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Gitlab') }}
+      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Gitlab') }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         branchName: ${{ steps['prepare-publish'].output.generatedBranchName }}
@@ -483,7 +470,7 @@ spec:
       input:
         catalogInfoUrl: ${{ steps['prepare-publish'].output.generatedCatalogInfoUrl }}
         optional: true
-    
+
     - id: dispatch-ee-build
       action: github:actions:dispatch
       name: Start EE Build Workflow
@@ -504,24 +491,24 @@ spec:
           ${{ steps['create-ee-definition'].output.readmeContent }}
 
     links:
-      - title: ${{ parameters.publishAndBuild.sourceControlProvider }} Repository
+      - title: ${{ parameters.publishAndBuild.sourceControlProvider.provider }} Repository
         url: ${{ steps['prepare-publish'].output.generatedFullRepoUrl }}
         if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) }}
-        icon: ${{ parameters.publishAndBuild.sourceControlProvider | lower }}
+        icon: ${{ parameters.publishAndBuild.sourceControlProvider.provider | lower }}
 
       - title: GitHub Pull Request
         url: ${{ steps['publish-github-pull-request'].output.remoteUrl }}
-        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Github') }}
+        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Github') }}
         icon: github
 
-      - title: ${{ parameters.publishAndBuild.sourceControlProvider }} EE Build Workflow Run
+      - title: ${{ parameters.publishAndBuild.sourceControlProvider.provider }} EE Build Workflow Run
         url: "https://${{ steps['prepare-publish'].output.normalizedRepoUrl }}/actions/workflows/ee-build.yml"
         if: ${{ (parameters.publishAndBuild.buildExecutionEnvironment == true) }}
         icon: github
 
       - title: GitLab Merge Request
         url: ${{ steps['publish-gitlab-merge-request'].output.mergeRequestUrl	}}
-        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Gitlab') }}
+        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Gitlab') }}
 
 
       - title: View details in catalog

--- a/templates/ee-network-automation.yaml
+++ b/templates/ee-network-automation.yaml
@@ -246,7 +246,7 @@ spec:
                     sourceControlProvider:
                       title: Select source control provider
                       type: object
-                      ui:field: ScmAuthPicker
+                      ui:field: ScmSelector
                       ui:options:
                         providers:
                           - label: Github

--- a/templates/ee-network-automation.yaml
+++ b/templates/ee-network-automation.yaml
@@ -272,7 +272,7 @@ spec:
                             sourceControlProvider:
                               properties:
                                 provider:
-                                  const: Github
+                                  const: github
                             buildExecutionEnvironment:
                               title: Build Execution Environment
                               description: Trigger a build of the Execution Environment after publishing.
@@ -349,7 +349,7 @@ spec:
                             sourceControlProvider:
                               properties:
                                 provider:
-                                  const: Gitlab
+                                  const: gitlab
                 - properties:
                     publishToSCM:
                       const: false
@@ -421,7 +421,7 @@ spec:
     - id: publish-github
       name: Create and publish to a new GitHub Repository
       action: publish:github
-      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Github') }}
+      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'github') }}
       input:
         description: ${{ parameters.templateDescription }}
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
@@ -433,7 +433,7 @@ spec:
     - id: publish-gitlab
       name: Create and publish to a new GitLab Repository
       action: publish:gitlab
-      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Gitlab') }}
+      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab') }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         defaultBranch: 'main'
@@ -444,7 +444,7 @@ spec:
     - id: publish-github-pull-request
       name: Publish generated files as a Github Pull Request
       action: publish:github:pull-request
-      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Github') }}
+      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'github') }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         branchName: ${{ steps['prepare-publish'].output.generatedBranchName }}
@@ -456,7 +456,7 @@ spec:
     - id: publish-gitlab-merge-request
       name: Publish generated files as a Gitlab Merge Request
       action: publish:gitlab:merge-request
-      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Gitlab') }}
+      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab') }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         branchName: ${{ steps['prepare-publish'].output.generatedBranchName }}
@@ -492,24 +492,24 @@ spec:
           ${{ steps['create-ee-definition'].output.readmeContent }}
 
     links:
-      - title: ${{ parameters.publishAndBuild.sourceControlProvider.provider }} Repository
+      - title: ${{ parameters.publishAndBuild.sourceControlProvider.providerLabel }} Repository
         url: ${{ steps['prepare-publish'].output.generatedFullRepoUrl }}
         if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) }}
         icon: ${{ parameters.publishAndBuild.sourceControlProvider.provider | lower }}
 
       - title: GitHub Pull Request
         url: ${{ steps['publish-github-pull-request'].output.remoteUrl }}
-        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Github') }}
+        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'github') }}
         icon: github
 
-      - title: ${{ parameters.publishAndBuild.sourceControlProvider.provider }} EE Build Workflow Run
+      - title: ${{ parameters.publishAndBuild.sourceControlProvider.providerLabel }} EE Build Workflow Run
         url: "https://${{ steps['prepare-publish'].output.normalizedRepoUrl }}/actions/workflows/ee-build.yml"
         if: ${{ (parameters.publishAndBuild.buildExecutionEnvironment == true) }}
         icon: github
 
       - title: GitLab Merge Request
         url: ${{ steps['publish-gitlab-merge-request'].output.mergeRequestUrl	}}
-        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Gitlab') }}
+        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab') }}
 
 
       - title: View details in catalog

--- a/templates/ee-network-automation.yaml
+++ b/templates/ee-network-automation.yaml
@@ -245,13 +245,16 @@ spec:
                       const: true
                     sourceControlProvider:
                       title: Select source control provider
-                      description: Choose your source control provider
-                      type: string
-                      enum:
-                        - Github
-                        - Gitlab
+                      type: object
                       ui:field: ScmAuthPicker
                       ui:options:
+                        providers:
+                          - label: Github
+                            provider: github
+                            host: github.com
+                          - label: Gitlab
+                            provider: gitlab
+                            host: gitlab.com
                         requestUserCredentials:
                           secretsKey: USER_OAUTH_TOKEN
                           additionalScopes:
@@ -260,34 +263,16 @@ spec:
                               - workflow
                             gitlab:
                               - write_repository
-                        hostMapping:
-                          Github: github.com
-                          Gitlab: gitlab.com
-                    repositoryOwner:
-                      title: Git organization or username
-                      type: string
-                      description: The organization or username that owns the Git repository
-                    repositoryName:
-                      title: Target Repository Name
-                      type: string
-                      description: Specify the name of the repository where the EE definition files will be published.
-                    createNewRepository:
-                      title: Create new repository
-                      type: boolean
-                      description: Create a new repository, if the specified one does not exist.
-                      default: false
-                      ui:help: "If unchecked, a new repository will not be created if the specified one does not exist. The generated files will not be published to a repository."
                   required:
                     - sourceControlProvider
-                    - repositoryOwner
-                    - repositoryName
-                    - createNewRepository
                   dependencies:
                     sourceControlProvider:
                       oneOf:
                         - properties:
                             sourceControlProvider:
-                              const: Github
+                              properties:
+                                provider:
+                                  const: Github
                             buildExecutionEnvironment:
                               title: Build Execution Environment
                               description: Trigger a build of the Execution Environment after publishing.
@@ -362,7 +347,9 @@ spec:
                                       const: false
                         - properties:
                             sourceControlProvider:
-                              const: Gitlab
+                              properties:
+                                provider:
+                                  const: Gitlab
                 - properties:
                     publishToSCM:
                       const: false
@@ -400,10 +387,10 @@ spec:
       name: Prepare for publishing
       if: ${{ parameters.publishAndBuild.publishToSCM }}
       input:
-        sourceControlProvider: ${{ parameters.publishAndBuild.sourceControlProvider }}
-        repositoryOwner: ${{ parameters.publishAndBuild.repositoryOwner }}
-        repositoryName: ${{ parameters.publishAndBuild.repositoryName }}
-        createNewRepository: ${{ parameters.publishAndBuild.createNewRepository }}
+        sourceControlProvider: ${{ parameters.publishAndBuild.sourceControlProvider.provider }}
+        repositoryOwner: ${{ parameters.publishAndBuild.sourceControlProvider.org }}
+        repositoryName: ${{ parameters.publishAndBuild.sourceControlProvider.repoName }}
+        createNewRepository: ${{ not parameters.publishAndBuild.sourceControlProvider.repoExists }}
         eeFileName: ${{ parameters.eeFileName }}
         contextDirName: ${{ steps['create-ee-definition'].output.contextDirName }}
         token: ${{ secrets.USER_OAUTH_TOKEN }}
@@ -424,7 +411,7 @@ spec:
             annotations:
               backstage.io/techdocs-ref: dir:.
               backstage.io/managed-by-location: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
-              ansible.io/scm-provider: ${{ parameters.publishAndBuild.sourceControlProvider }}
+              ansible.io/scm-provider: ${{ parameters.publishAndBuild.sourceControlProvider.provider }}
           spec:
             type: execution-environment
             owner: ${{ steps['create-ee-definition'].output.owner }}
@@ -434,7 +421,7 @@ spec:
     - id: publish-github
       name: Create and publish to a new GitHub Repository
       action: publish:github
-      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Github') }}
+      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Github') }}
       input:
         description: ${{ parameters.templateDescription }}
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
@@ -446,7 +433,7 @@ spec:
     - id: publish-gitlab
       name: Create and publish to a new GitLab Repository
       action: publish:gitlab
-      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Gitlab') }}
+      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Gitlab') }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         defaultBranch: 'main'
@@ -457,7 +444,7 @@ spec:
     - id: publish-github-pull-request
       name: Publish generated files as a Github Pull Request
       action: publish:github:pull-request
-      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Github') }}
+      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Github') }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         branchName: ${{ steps['prepare-publish'].output.generatedBranchName }}
@@ -469,7 +456,7 @@ spec:
     - id: publish-gitlab-merge-request
       name: Publish generated files as a Gitlab Merge Request
       action: publish:gitlab:merge-request
-      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Gitlab') }}
+      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Gitlab') }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         branchName: ${{ steps['prepare-publish'].output.generatedBranchName }}
@@ -484,7 +471,7 @@ spec:
       input:
         catalogInfoUrl: ${{ steps['prepare-publish'].output.generatedCatalogInfoUrl }}
         optional: true
-    
+
     - id: dispatch-ee-build
       action: github:actions:dispatch
       name: Start EE Build Workflow
@@ -505,24 +492,24 @@ spec:
           ${{ steps['create-ee-definition'].output.readmeContent }}
 
     links:
-      - title: ${{ parameters.publishAndBuild.sourceControlProvider }} Repository
+      - title: ${{ parameters.publishAndBuild.sourceControlProvider.provider }} Repository
         url: ${{ steps['prepare-publish'].output.generatedFullRepoUrl }}
         if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) }}
-        icon: ${{ parameters.publishAndBuild.sourceControlProvider | lower }}
+        icon: ${{ parameters.publishAndBuild.sourceControlProvider.provider | lower }}
 
       - title: GitHub Pull Request
         url: ${{ steps['publish-github-pull-request'].output.remoteUrl }}
-        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Github') }}
+        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Github') }}
         icon: github
 
-      - title: ${{ parameters.publishAndBuild.sourceControlProvider }} EE Build Workflow Run
+      - title: ${{ parameters.publishAndBuild.sourceControlProvider.provider }} EE Build Workflow Run
         url: "https://${{ steps['prepare-publish'].output.normalizedRepoUrl }}/actions/workflows/ee-build.yml"
         if: ${{ (parameters.publishAndBuild.buildExecutionEnvironment == true) }}
         icon: github
 
       - title: GitLab Merge Request
         url: ${{ steps['publish-gitlab-merge-request'].output.mergeRequestUrl	}}
-        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Gitlab') }}
+        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Gitlab') }}
 
 
       - title: View details in catalog

--- a/templates/ee-start-from-scratch.yaml
+++ b/templates/ee-start-from-scratch.yaml
@@ -266,7 +266,7 @@ spec:
                             sourceControlProvider:
                               properties:
                                 provider:
-                                  const: Github
+                                  const: github
                             buildExecutionEnvironment:
                               title: Build Execution Environment
                               description: Trigger a build of the Execution Environment after publishing.
@@ -343,7 +343,7 @@ spec:
                             sourceControlProvider:
                               properties:
                                 provider:
-                                  const: Gitlab
+                                  const: gitlab
                 - properties:
                     publishToSCM:
                       const: false
@@ -415,7 +415,7 @@ spec:
     - id: publish-github
       name: Create and publish to a new GitHub Repository
       action: publish:github
-      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Github') }}
+      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'github') }}
       input:
         description: ${{ parameters.templateDescription }}
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
@@ -427,7 +427,7 @@ spec:
     - id: publish-gitlab
       name: Create and publish to a new GitLab Repository
       action: publish:gitlab
-      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Gitlab') }}
+      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab') }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         defaultBranch: 'main'
@@ -438,7 +438,7 @@ spec:
     - id: publish-github-pull-request
       name: Publish generated files as a Github Pull Request
       action: publish:github:pull-request
-      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Github') }}
+      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'github') }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         branchName: ${{ steps['prepare-publish'].output.generatedBranchName }}
@@ -450,7 +450,7 @@ spec:
     - id: publish-gitlab-merge-request
       name: Publish generated files as a Gitlab Merge Request
       action: publish:gitlab:merge-request
-      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Gitlab') }}
+      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab') }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         branchName: ${{ steps['prepare-publish'].output.generatedBranchName }}
@@ -486,24 +486,24 @@ spec:
           ${{ steps['create-ee-definition'].output.readmeContent }}
 
     links:
-      - title: ${{ parameters.publishAndBuild.sourceControlProvider.provider }} Repository
+      - title: ${{ parameters.publishAndBuild.sourceControlProvider.providerLabel }} Repository
         url: ${{ steps['prepare-publish'].output.generatedFullRepoUrl }}
         if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) }}
-        icon: ${{ parameters.publishAndBuild.sourceControlProvider.provider | lower }}
+        icon: ${{ parameters.publishAndBuild.sourceControlProvider.provider }}
 
       - title: GitHub Pull Request
         url: ${{ steps['publish-github-pull-request'].output.remoteUrl }}
-        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Github') }}
+        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'github') }}
         icon: github
 
-      - title: ${{ parameters.publishAndBuild.sourceControlProvider.provider }} EE Build Workflow Run
+      - title: ${{ parameters.publishAndBuild.sourceControlProvider.providerLabel }} EE Build Workflow Run
         url: "https://${{ steps['prepare-publish'].output.normalizedRepoUrl }}/actions/workflows/ee-build.yml"
         if: ${{ (parameters.publishAndBuild.buildExecutionEnvironment == true) }}
         icon: github
 
       - title: GitLab Merge Request
         url: ${{ steps['publish-gitlab-merge-request'].output.mergeRequestUrl	}}
-        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Gitlab') }}
+        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab') }}
 
 
       - title: View details in catalog

--- a/templates/ee-start-from-scratch.yaml
+++ b/templates/ee-start-from-scratch.yaml
@@ -240,7 +240,7 @@ spec:
                     sourceControlProvider:
                       title: Select source control provider
                       type: object
-                      ui:field: ScmAuthPicker
+                      ui:field: ScmSelector
                       ui:options:
                         providers:
                           - label: Github

--- a/templates/ee-start-from-scratch.yaml
+++ b/templates/ee-start-from-scratch.yaml
@@ -239,13 +239,16 @@ spec:
                       const: true
                     sourceControlProvider:
                       title: Select source control provider
-                      description: Choose your source control provider
-                      type: string
-                      enum:
-                        - Github
-                        - Gitlab
+                      type: object
                       ui:field: ScmAuthPicker
                       ui:options:
+                        providers:
+                          - label: Github
+                            provider: github
+                            host: github.com
+                          - label: Gitlab
+                            provider: gitlab
+                            host: gitlab.com
                         requestUserCredentials:
                           secretsKey: USER_OAUTH_TOKEN
                           additionalScopes:
@@ -254,34 +257,16 @@ spec:
                               - workflow
                             gitlab:
                               - write_repository
-                        hostMapping:
-                          Github: github.com
-                          Gitlab: gitlab.com
-                    repositoryOwner:
-                      title: Git organization or username
-                      type: string
-                      description: The organization or username that owns the Git repository
-                    repositoryName:
-                      title: Target Repository Name
-                      type: string
-                      description: Specify the name of the repository where the EE definition files will be published.
-                    createNewRepository:
-                      title: Create new repository
-                      type: boolean
-                      description: Create a new repository, if the specified one does not exist.
-                      default: false
-                      ui:help: "If unchecked, a new repository will not be created if the specified one does not exist. The generated files will not be published to a repository."
                   required:
                     - sourceControlProvider
-                    - repositoryOwner
-                    - repositoryName
-                    - createNewRepository
                   dependencies:
                     sourceControlProvider:
                       oneOf:
                         - properties:
                             sourceControlProvider:
-                              const: Github
+                              properties:
+                                provider:
+                                  const: Github
                             buildExecutionEnvironment:
                               title: Build Execution Environment
                               description: Trigger a build of the Execution Environment after publishing.
@@ -356,7 +341,9 @@ spec:
                                       const: false
                         - properties:
                             sourceControlProvider:
-                              const: Gitlab
+                              properties:
+                                provider:
+                                  const: Gitlab
                 - properties:
                     publishToSCM:
                       const: false
@@ -394,10 +381,10 @@ spec:
       name: Prepare for publishing
       if: ${{ parameters.publishAndBuild.publishToSCM }}
       input:
-        sourceControlProvider: ${{ parameters.publishAndBuild.sourceControlProvider }}
-        repositoryOwner: ${{ parameters.publishAndBuild.repositoryOwner }}
-        repositoryName: ${{ parameters.publishAndBuild.repositoryName }}
-        createNewRepository: ${{ parameters.publishAndBuild.createNewRepository }}
+        sourceControlProvider: ${{ parameters.publishAndBuild.sourceControlProvider.provider }}
+        repositoryOwner: ${{ parameters.publishAndBuild.sourceControlProvider.org }}
+        repositoryName: ${{ parameters.publishAndBuild.sourceControlProvider.repoName }}
+        createNewRepository: ${{ not parameters.publishAndBuild.sourceControlProvider.repoExists }}
         eeFileName: ${{ parameters.eeFileName }}
         contextDirName: ${{ steps['create-ee-definition'].output.contextDirName }}
         token: ${{ secrets.USER_OAUTH_TOKEN }}
@@ -418,7 +405,7 @@ spec:
             annotations:
               backstage.io/techdocs-ref: dir:.
               backstage.io/managed-by-location: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
-              ansible.io/scm-provider: ${{ parameters.publishAndBuild.sourceControlProvider }}
+              ansible.io/scm-provider: ${{ parameters.publishAndBuild.sourceControlProvider.provider }}
           spec:
             type: execution-environment
             owner: ${{ steps['create-ee-definition'].output.owner }}
@@ -428,7 +415,7 @@ spec:
     - id: publish-github
       name: Create and publish to a new GitHub Repository
       action: publish:github
-      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Github') }}
+      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Github') }}
       input:
         description: ${{ parameters.templateDescription }}
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
@@ -440,7 +427,7 @@ spec:
     - id: publish-gitlab
       name: Create and publish to a new GitLab Repository
       action: publish:gitlab
-      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Gitlab') }}
+      if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Gitlab') }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         defaultBranch: 'main'
@@ -451,7 +438,7 @@ spec:
     - id: publish-github-pull-request
       name: Publish generated files as a Github Pull Request
       action: publish:github:pull-request
-      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Github') }}
+      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Github') }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         branchName: ${{ steps['prepare-publish'].output.generatedBranchName }}
@@ -463,7 +450,7 @@ spec:
     - id: publish-gitlab-merge-request
       name: Publish generated files as a Gitlab Merge Request
       action: publish:gitlab:merge-request
-      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Gitlab') }}
+      if: ${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Gitlab') }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         branchName: ${{ steps['prepare-publish'].output.generatedBranchName }}
@@ -478,7 +465,7 @@ spec:
       input:
         catalogInfoUrl: ${{ steps['prepare-publish'].output.generatedCatalogInfoUrl }}
         optional: true
-    
+
     - id: dispatch-ee-build
       action: github:actions:dispatch
       name: Start EE Build Workflow
@@ -499,24 +486,24 @@ spec:
           ${{ steps['create-ee-definition'].output.readmeContent }}
 
     links:
-      - title: ${{ parameters.publishAndBuild.sourceControlProvider }} Repository
+      - title: ${{ parameters.publishAndBuild.sourceControlProvider.provider }} Repository
         url: ${{ steps['prepare-publish'].output.generatedFullRepoUrl }}
         if: ${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) }}
-        icon: ${{ parameters.publishAndBuild.sourceControlProvider | lower }}
+        icon: ${{ parameters.publishAndBuild.sourceControlProvider.provider | lower }}
 
       - title: GitHub Pull Request
         url: ${{ steps['publish-github-pull-request'].output.remoteUrl }}
-        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Github') }}
+        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Github') }}
         icon: github
 
-      - title: ${{ parameters.publishAndBuild.sourceControlProvider }} EE Build Workflow Run
+      - title: ${{ parameters.publishAndBuild.sourceControlProvider.provider }} EE Build Workflow Run
         url: "https://${{ steps['prepare-publish'].output.normalizedRepoUrl }}/actions/workflows/ee-build.yml"
         if: ${{ (parameters.publishAndBuild.buildExecutionEnvironment == true) }}
         icon: github
 
       - title: GitLab Merge Request
         url: ${{ steps['publish-gitlab-merge-request'].output.mergeRequestUrl	}}
-        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Gitlab') }}
+        if: ${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider.provider == 'Gitlab') }}
 
 
       - title: View details in catalog


### PR DESCRIPTION
## Description

Updates all three EE templates (`ee-start-from-scratch`, `ee-cloud-automation`, `ee-network-automation`) to work with the enhanced ScmAuthPicker component:

- sourceControlProvider changes from `type: string` to `type: object` and provider options move from `enum/hostMapping` to a unified providers list in `ui:options`.

- `repositoryOwner`, `repositoryName`, and `createNewRepository` fields removed. Those are now handled by the component via `.org`, `.repoName`, and `.repoExists`.

- All step inputs and conditionals updated to dot-access the object (e.g., `sourceControlProvider.provider` == 'Github').