### PR TITLE
Register EE published repo as an entity

### DIFF
--- a/templates/ee-start-from-scratch.yaml
+++ b/templates/ee-start-from-scratch.yaml
@@ -411,6 +411,37 @@ spec:
             owner: ${{ steps['create-ee-definition'].output.owner }}
             lifecycle: production
 
+    - id: create-repo-catalog-info
+      action: catalog:write
+      name: Create catalog component file for the Git Repository
+      if: ${{ parameters.publishAndBuild.publishToSCM }}
+      input:
+        filePath: catalog-info.yaml
+        entity:
+          apiVersion: backstage.io/v1alpha1
+          kind: Component
+          metadata:
+            name: ${{ parameters.publishAndBuild.sourceControlProvider.repoName }}
+            title: ${{ parameters.publishAndBuild.sourceControlProvider.repoName }}
+            description: Git repository containing Ansible Execution Environment definitions
+            tags:
+              - git-repository
+              - ${{ parameters.publishAndBuild.sourceControlProvider.repoName | lower }}
+              - ansible-ee-source
+            annotations:
+              backstage.io/managed-by-location: ${{ steps['prepare-publish'].output.normalizedRepoUrl }}
+              ansible.io/scm-provider: ${{ parameters.publishAndBuild.sourceControlProvider.provider }}
+              ansible.io/scm-organization: ${{ parameters.publishAndBuild.sourceControlProvider.org }}
+              ansible.io/scm-repository: ${{ parameters.publishAndBuild.sourceControlProvider.repoName }}
+          spec:
+            type: git-repository
+            lifecycle: production
+            owner: ${{ steps['create-ee-definition'].output.owner }}
+            dependsOn:
+              - component:default/${{ parameters.eeFileName }}
+            repository_ee_count: 1 # how can we update this depending upon the number of EEs published to a repo?
+            repository_default_branch: ${{ steps['prepare-publish'].output.generatedBranchName or 'main' }}
+
     # Step 5: Create and publish to a new GitHub Repository
     - id: publish-github
       name: Create and publish to a new GitHub Repository
@@ -464,6 +495,14 @@ spec:
       if: ${{ parameters.publishAndBuild.publishToSCM }}
       input:
         catalogInfoUrl: ${{ steps['prepare-publish'].output.generatedCatalogInfoUrl }}
+        optional: true
+
+    - id: register-repo-catalog-component
+      name: Register Git Repository as a Catalog Component
+      action: catalog:register
+      if: ${{ parameters.publishAndBuild.publishToSCM }}
+      input:
+        catalogInfoUrl: "${{ ('https://' + steps['prepare-publish'].output.normalizedRepoUrl + '/blob/main/catalog-info.yaml') if (parameters.publishAndBuild.sourceControlProvider.provider == 'github') else ('https://' + steps['prepare-publish'].output.normalizedRepoUrl + '/-/blob/main/catalog-info.yaml') }}"
         optional: true
 
     - id: dispatch-ee-build


### PR DESCRIPTION
## Description

Register EE published repo as an entity.

Creates a catalog info file and publishes it with the repository. This catalog info file is placed at the root of the repo and registers it as a 'git-repository' (see `spec.type`). 

The change makes the published ee repo appear in Git repos view and shows the CI activities without making any changes into the `ansible-backstage-plugins` repo. If this change is acceptable, then the only change need would be in the ee-template file in the scaffolder plugin to match this, so that the custom ee templates created and registered would show the similar behaviour.

## Concerns

How do we update the `repository-ee-count` (currently hardcoded as `1`) when multiple EEs are published to the same repository?

There is no README available at the root of the repo due to which the README container in the repo details page remains empty.

## Screenshots

- Git repositories catalog:

<img width="1357" height="280" alt="Screenshot 2026-04-25 at 05 25 49" src="https://github.com/user-attachments/assets/11db9b75-113e-451a-9ac9-103c7a962acb" />

- CI Activity Tab:

<img width="1636" height="327" alt="Screenshot 2026-04-25 at 05 36 13" src="https://github.com/user-attachments/assets/9d2ae29d-d326-4c56-8cc7-ee974e3a9971" />

