### PR TITLE
Pass EE_IMAGE_BUILD_TAG to GitLab pipeline trigger in EE template

### DIFF
--- a/templates/ee-cloud-automation.yaml
+++ b/templates/ee-cloud-automation.yaml
@@ -573,7 +573,7 @@ spec:
         branch: ${{ steps['prepare-publish'].output.generatedBranchName or 'main' }}
         token: ${{ secrets.USER_OAUTH_TOKEN }}
         variables:
-          IMAGE_BUILD_TAG: ${{ parameters.publishAndBuild.buildImageTag or '' }}
+          EE_IMAGE_BUILD_TAG: ${{ parameters.publishAndBuild.buildImageTag or '' }}
 
   output:
     text:

--- a/templates/ee-cloud-automation.yaml
+++ b/templates/ee-cloud-automation.yaml
@@ -559,7 +559,7 @@ spec:
         workflowId: ee-build.yml
         branchOrTagName: ${{ steps['prepare-publish'].output.generatedBranchName or 'main' }}
         workflowInputs:
-          image_build_tag: ${{ parameters.publishAndBuild.buildImageTag or '' }}
+          ee_image_build_tag: ${{ parameters.publishAndBuild.buildImageTag or '' }}
         token: ${{ secrets.USER_OAUTH_TOKEN }}
 
     - id: dispatch-ee-build-gitlab

--- a/templates/ee-cloud-automation.yaml
+++ b/templates/ee-cloud-automation.yaml
@@ -572,6 +572,8 @@ spec:
         tokenDescription: "EE Build Pipeline Trigger"
         branch: ${{ steps['prepare-publish'].output.generatedBranchName or 'main' }}
         token: ${{ secrets.USER_OAUTH_TOKEN }}
+        variables:
+          IMAGE_BUILD_TAG: ${{ parameters.publishAndBuild.buildImageTag or '' }}
 
   output:
     text:

--- a/templates/ee-network-automation.yaml
+++ b/templates/ee-network-automation.yaml
@@ -561,7 +561,7 @@ spec:
         workflowId: ee-build.yml
         branchOrTagName: ${{ steps['prepare-publish'].output.generatedBranchName or 'main' }}
         workflowInputs:
-          image_build_tag: ${{ parameters.publishAndBuild.buildImageTag or '' }}
+          ee_image_build_tag: ${{ parameters.publishAndBuild.buildImageTag or '' }}
         token: ${{ secrets.USER_OAUTH_TOKEN }}
 
     - id: dispatch-ee-build-gitlab

--- a/templates/ee-network-automation.yaml
+++ b/templates/ee-network-automation.yaml
@@ -574,6 +574,8 @@ spec:
         tokenDescription: "EE Build Pipeline Trigger"
         branch: ${{ steps['prepare-publish'].output.generatedBranchName or 'main' }}
         token: ${{ secrets.USER_OAUTH_TOKEN }}
+        variables:
+          IMAGE_BUILD_TAG: ${{ parameters.publishAndBuild.buildImageTag or '' }}
 
   output:
     text:

--- a/templates/ee-network-automation.yaml
+++ b/templates/ee-network-automation.yaml
@@ -575,7 +575,7 @@ spec:
         branch: ${{ steps['prepare-publish'].output.generatedBranchName or 'main' }}
         token: ${{ secrets.USER_OAUTH_TOKEN }}
         variables:
-          IMAGE_BUILD_TAG: ${{ parameters.publishAndBuild.buildImageTag or '' }}
+          EE_IMAGE_BUILD_TAG: ${{ parameters.publishAndBuild.buildImageTag or '' }}
 
   output:
     text:

--- a/templates/ee-start-from-scratch.yaml
+++ b/templates/ee-start-from-scratch.yaml
@@ -563,6 +563,8 @@ spec:
         tokenDescription: "EE Build Pipeline Trigger"
         branch: ${{ steps['prepare-publish'].output.generatedBranchName or 'main' }}
         token: ${{ secrets.USER_OAUTH_TOKEN }}
+        variables:
+          IMAGE_BUILD_TAG: ${{ parameters.publishAndBuild.buildImageTag or '' }}
 
   output:
     text:

--- a/templates/ee-start-from-scratch.yaml
+++ b/templates/ee-start-from-scratch.yaml
@@ -550,7 +550,7 @@ spec:
         workflowId: ee-build.yml
         branchOrTagName: ${{ steps['prepare-publish'].output.generatedBranchName or 'main' }}
         workflowInputs:
-          image_build_tag: ${{ parameters.publishAndBuild.buildImageTag or '' }}
+          ee_image_build_tag: ${{ parameters.publishAndBuild.buildImageTag or '' }}
         token: ${{ secrets.USER_OAUTH_TOKEN }}
 
     - id: dispatch-ee-build-gitlab

--- a/templates/ee-start-from-scratch.yaml
+++ b/templates/ee-start-from-scratch.yaml
@@ -564,7 +564,7 @@ spec:
         branch: ${{ steps['prepare-publish'].output.generatedBranchName or 'main' }}
         token: ${{ secrets.USER_OAUTH_TOKEN }}
         variables:
-          IMAGE_BUILD_TAG: ${{ parameters.publishAndBuild.buildImageTag or '' }}
+          EE_IMAGE_BUILD_TAG: ${{ parameters.publishAndBuild.buildImageTag or '' }}
 
   output:
     text:


### PR DESCRIPTION
## Summary

- Add `variables` input to the `gitlab:pipeline:trigger` step in `ee-start-from-scratch.yaml`
- Pass `EE_IMAGE_BUILD_TAG` from the user's `buildImageTag` parameter to the GitLab pipeline
- Correct github input after creator update

## Why
The GitHub dispatch step already passes `image_build_tag` via `workflowInputs`, but the GitLab dispatch step was not passing any build variables. This meant the user-specified image tag from the scaffolder wizard was ignored during the initial GitLab pipeline build.