### PR TITLE
[AAP-84907] Gate EE build dispatch steps on publishToSCM

### DIFF
--- a/templates/ee-cloud-automation.yaml
+++ b/templates/ee-cloud-automation.yaml
@@ -553,7 +553,7 @@ spec:
     - id: dispatch-ee-build
       action: github:actions:dispatch
       name: Start EE Build Workflow
-      if: ${{ parameters.publishAndBuild.buildExecutionEnvironment and parameters.publishAndBuild.sourceControlProvider.provider == 'github' }}
+      if: ${{ parameters.publishAndBuild.publishToSCM and parameters.publishAndBuild.buildExecutionEnvironment and parameters.publishAndBuild.sourceControlProvider.provider == 'github' }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         workflowId: ee-build.yml
@@ -565,7 +565,7 @@ spec:
     - id: dispatch-ee-build-gitlab
       action: gitlab:pipeline:trigger
       name: Start EE Build Pipeline
-      if: ${{ parameters.publishAndBuild.buildExecutionEnvironment and parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab' }}
+      if: ${{ parameters.publishAndBuild.publishToSCM and parameters.publishAndBuild.buildExecutionEnvironment and parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab' }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         projectId: ${{ steps['publish-gitlab'].output.projectId or steps['prepare-publish'].output.gitlabProjectId }}
@@ -594,12 +594,12 @@ spec:
 
       - title: ${{ parameters.publishAndBuild.sourceControlProvider.providerLabel }} EE Build Workflow Run
         url: "https://${{ steps['prepare-publish'].output.normalizedRepoUrl }}/actions/workflows/ee-build.yml"
-        if: ${{ parameters.publishAndBuild.buildExecutionEnvironment == true and parameters.publishAndBuild.sourceControlProvider.provider == 'github' }}
+        if: ${{ parameters.publishAndBuild.publishToSCM and parameters.publishAndBuild.buildExecutionEnvironment == true and parameters.publishAndBuild.sourceControlProvider.provider == 'github' }}
         icon: github
 
       - title: GitLab EE Build Pipeline Run
         url: ${{ steps['dispatch-ee-build-gitlab'].output.pipelineUrl }}
-        if: ${{ parameters.publishAndBuild.buildExecutionEnvironment == true and parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab' }}
+        if: ${{ parameters.publishAndBuild.publishToSCM and parameters.publishAndBuild.buildExecutionEnvironment == true and parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab' }}
         icon: gitlab
 
       - title: GitLab Merge Request

--- a/templates/ee-network-automation.yaml
+++ b/templates/ee-network-automation.yaml
@@ -555,7 +555,7 @@ spec:
     - id: dispatch-ee-build
       action: github:actions:dispatch
       name: Start EE Build Workflow
-      if: ${{ parameters.publishAndBuild.buildExecutionEnvironment and parameters.publishAndBuild.sourceControlProvider.provider == 'github' }}
+      if: ${{ parameters.publishAndBuild.publishToSCM and parameters.publishAndBuild.buildExecutionEnvironment and parameters.publishAndBuild.sourceControlProvider.provider == 'github' }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         workflowId: ee-build.yml
@@ -567,7 +567,7 @@ spec:
     - id: dispatch-ee-build-gitlab
       action: gitlab:pipeline:trigger
       name: Start EE Build Pipeline
-      if: ${{ parameters.publishAndBuild.buildExecutionEnvironment and parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab' }}
+      if: ${{ parameters.publishAndBuild.publishToSCM and parameters.publishAndBuild.buildExecutionEnvironment and parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab' }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         projectId: ${{ steps['publish-gitlab'].output.projectId or steps['prepare-publish'].output.gitlabProjectId }}
@@ -596,12 +596,12 @@ spec:
 
       - title: ${{ parameters.publishAndBuild.sourceControlProvider.providerLabel }} EE Build Workflow Run
         url: "https://${{ steps['prepare-publish'].output.normalizedRepoUrl }}/actions/workflows/ee-build.yml"
-        if: ${{ parameters.publishAndBuild.buildExecutionEnvironment == true and parameters.publishAndBuild.sourceControlProvider.provider == 'github' }}
+        if: ${{ parameters.publishAndBuild.publishToSCM and parameters.publishAndBuild.buildExecutionEnvironment == true and parameters.publishAndBuild.sourceControlProvider.provider == 'github' }}
         icon: github
 
       - title: GitLab EE Build Pipeline Run
         url: ${{ steps['dispatch-ee-build-gitlab'].output.pipelineUrl }}
-        if: ${{ parameters.publishAndBuild.buildExecutionEnvironment == true and parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab' }}
+        if: ${{ parameters.publishAndBuild.publishToSCM and parameters.publishAndBuild.buildExecutionEnvironment == true and parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab' }}
         icon: gitlab
 
       - title: GitLab Merge Request

--- a/templates/ee-start-from-scratch.yaml
+++ b/templates/ee-start-from-scratch.yaml
@@ -544,7 +544,7 @@ spec:
     - id: dispatch-ee-build
       action: github:actions:dispatch
       name: Start EE Build Workflow
-      if: ${{ parameters.publishAndBuild.buildExecutionEnvironment and parameters.publishAndBuild.sourceControlProvider.provider == 'github' }}
+      if: ${{ parameters.publishAndBuild.publishToSCM and parameters.publishAndBuild.buildExecutionEnvironment and parameters.publishAndBuild.sourceControlProvider.provider == 'github' }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         workflowId: ee-build.yml
@@ -556,7 +556,7 @@ spec:
     - id: dispatch-ee-build-gitlab
       action: gitlab:pipeline:trigger
       name: Start EE Build Pipeline
-      if: ${{ parameters.publishAndBuild.buildExecutionEnvironment and parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab' }}
+      if: ${{ parameters.publishAndBuild.publishToSCM and parameters.publishAndBuild.buildExecutionEnvironment and parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab' }}
       input:
         repoUrl: ${{ steps['prepare-publish'].output.generatedRepoUrl }}
         projectId: ${{ steps['publish-gitlab'].output.projectId or steps['prepare-publish'].output.gitlabProjectId }}
@@ -585,12 +585,12 @@ spec:
 
       - title: ${{ parameters.publishAndBuild.sourceControlProvider.providerLabel }} EE Build Workflow Run
         url: "https://${{ steps['prepare-publish'].output.normalizedRepoUrl }}/actions/workflows/ee-build.yml"
-        if: ${{ parameters.publishAndBuild.buildExecutionEnvironment == true and parameters.publishAndBuild.sourceControlProvider.provider == 'github' }}
+        if: ${{ parameters.publishAndBuild.publishToSCM and parameters.publishAndBuild.buildExecutionEnvironment == true and parameters.publishAndBuild.sourceControlProvider.provider == 'github' }}
         icon: github
 
       - title: GitLab EE Build Pipeline Run
         url: ${{ steps['dispatch-ee-build-gitlab'].output.pipelineUrl }}
-        if: ${{ parameters.publishAndBuild.buildExecutionEnvironment == true and parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab' }}
+        if: ${{ parameters.publishAndBuild.publishToSCM and parameters.publishAndBuild.buildExecutionEnvironment == true and parameters.publishAndBuild.sourceControlProvider.provider == 'gitlab' }}
         icon: gitlab
 
       - title: GitLab Merge Request


### PR DESCRIPTION
## Summary

- Adds `parameters.publishAndBuild.publishToSCM` guard to the `dispatch-ee-build` and `dispatch-ee-build-gitlab` step conditions and their corresponding output links in all three EE templates
- Fixes a bug where unchecking "Publish to a Git repository" after checking "Build Execution Environment" caused stale form values to trigger the EE build dispatch, silently breaking the flow and hiding the "Download EE Files" button

## Root Cause Analysis

The `dispatch-ee-build` and `dispatch-ee-build-gitlab` steps only checked `buildExecutionEnvironment` and `sourceControlProvider.provider`, but **not** `publishToSCM`. RJSF does not clear stale values from `formData` when a field drops out of the resolved schema, so unchecking "Publish to a Git repository" hid the UI but left `buildExecutionEnvironment: true` in the submitted parameters. This caused:

1. The dispatch step to fire with `undefined` `repoUrl` (since `prepare-publish` was correctly skipped)
2. The task to error out silently
3. The `showDownloadButton` guard in `RunTask.tsx` to hide the download button (requires `taskStatus === 'completed'` and no `error`)

## Fix

Added `parameters.publishAndBuild.publishToSCM and` to the front of all four affected `if` conditions in each template, mirroring the pattern already used by `prepare-publish`, `create-catalog-info-file`, and the `publish-*` steps.

**Files changed:** `ee-cloud-automation.yaml`, `ee-network-automation.yaml`, `ee-start-from-scratch.yaml` (4 conditions each, 12 total)

## Test plan

- [ ] Check "Publish to a Git repository", select a provider, check "Build Execution Environment", then uncheck "Publish to a Git repository" and submit — flow should complete successfully
- [ ] "Download EE Files" button should appear on the RunTask results page
- [ ] With "Publish to a Git repository" and "Build Execution Environment" both checked, the EE build dispatch should still fire correctly (no regression)
- [ ] EE build output links should only appear when both publish and build are enabled

Fixes: https://redhat.atlassian.net/browse/AAP-84907